### PR TITLE
Remove bump release version


### DIFF
--- a/osa_cli_releases/cli.py
+++ b/osa_cli_releases/cli.py
@@ -66,20 +66,3 @@ def bump_arr():
     )
     args = parser.parse_args()
     releasing.update_ansible_role_requirements_file(filename=args['file'],branchname=args['os-branch'])
-
-
-def bump_oa_release_number():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "release_type",
-        choices=("bugfix", "feature", "milestone", "rc"),
-        help="The type of release to generate",
-        default="bugfix",
-    )
-    args = parser.parse_args()
-
-    current_version, filename = releasing.find_release_number()
-    print("Found version %s in %s" % (current_version, filename))
-    next_version = releasing.next_release_number(current_version, args.release_type)
-    print("Updating %s to %s" % (filename, next_version))
-    releasing.update_release_number(filename, ".".join(next_version))

--- a/osa_cli_releases/click.py
+++ b/osa_cli_releases/click.py
@@ -72,27 +72,3 @@ def bump_arr(global_ctx, **kwargs):
     releasing.update_ansible_role_requirements_file(
         filename=kwargs["file"], branchname=kwargs["os_branch"]
     )
-
-
-@releases.command("bump_release_number")
-@click.option(
-    "--release_type",
-    type=click.Choice(choices=["bugfix", "feature", "milestone", "rc"]),
-    help="The type of release to generate",
-    default="bugfix",
-)
-@click.pass_obj
-def bump_oa_release_number(global_ctx, **kwargs):
-    """ Updates the version of the release in tree
-    """
-    debug = global_ctx["debug"]
-
-    current_version, filename = releasing.find_release_number()
-    if debug:
-        print("Found version %s in %s" % (current_version, filename))
-    next_version = releasing.next_release_number(
-        current_version, kwargs["release_type"]
-    )
-    string_version = ".".join(next_version)
-    releasing.update_release_number(filename, string_version)
-    print("Updated version to {}".format(string_version))

--- a/osa_cli_releases/releasing.py
+++ b/osa_cli_releases/releasing.py
@@ -388,19 +388,3 @@ def increment_milestone_version(old_version, release_type):
     return new_version_parts
 
 
-def update_release_number(filename, version):
-    regex = re.compile("^openstack_release.*$")
-    for line in fileinput.input(filename, inplace=True):
-        match = regex.match(line)
-        if match:
-            print("openstack_release: {}".format(version))
-        else:
-            print(line, end="")
-
-    # yaml = YAML()
-    # with open(filename, "r") as versionfile:
-    #    y = yaml.load(versionfile)
-    # y["openstack_release"] = version
-    # with open(filename, "w") as versionfile:
-    #    yaml.explit_start = True
-    #    yaml.dump(y, versionfile, width=100)

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ console_scripts =
     bump-upstream-repos-shas = osa_cli_releases.cli:bump_upstream_repos_shas
     bump-ansible-role-requirements = osa_cli_releases.cli:bump_arr
     freeze-ansible-role-requirements = osa_cli_releases.cli:bump_arr
-    bump-oa-release-number = osa_cli_releases.cli:bump_oa_release_number
 
 osa_cli.plugins =
     releases = osa_cli_releases.click:releases


### PR DESCRIPTION


Now that the Ansible version is automatically fetched from setuptools,
there is no need to bump the version manually.

