### PR TITLE
Set python 3.5 requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifier =
 
 [options]
 packages = osa_cli_releases
-python_requires='>=3.5'
+python_requires = >=3.5
 install_requires =
     dulwich
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
 
 [options]
 packages = osa_cli_releases
+python_requires='>=3.5'
 install_requires =
     dulwich
     requests


### PR DESCRIPTION
Since tool supports only python 3.5+, it's worth mentioning inside setup.cfg