### PR TITLE
Allow to skip None trackbranch for roles

### DIFF
--- a/osa_cli_releases/releasing.py
+++ b/osa_cli_releases/releasing.py
@@ -239,6 +239,12 @@ def update_ansible_role_requirements_file(
 
     for role in all_roles:
         trackbranch = role.get("trackbranch")
+        if not trackbranch or trackbranch.lower() == "none":
+            print(
+                "Skipping role %s branch" % role["name"]
+            )
+            continue
+
         copyreleasenotes = False
 
         # We don't want to copy config_template renos even if it's an openstack


### PR DESCRIPTION
There's an option to disable bumps for upstream projects by
setting trackbranch to None.
However this didn't work for role bumps. This patch fixes this injustice