### PR TITLE
Replace branchname with trackbranch

### DIFF
--- a/osa_cli_releases/cli.py
+++ b/osa_cli_releases/cli.py
@@ -60,12 +60,8 @@ def bump_arr():
         help="path to ansible-role-requirements.yml file",
         default="ansible-role-requirements.yml",
     )
-    parser.add_argument(
-        "os-branch",
-        help="Branch to use to find the role SHA for openstack roles. Master will also freeze external roles.",
-    )
     args = parser.parse_args()
-    releasing.update_ansible_role_requirements_file(filename=args['file'],branchname=args['os-branch'])
+    releasing.update_ansible_role_requirements_file(filename=args['file'])
 
 
 def freeze_arr():

--- a/osa_cli_releases/click.py
+++ b/osa_cli_releases/click.py
@@ -70,7 +70,7 @@ def bump_arr(global_ctx, **kwargs):
     Also bumps roles from external sources when the branch to bump is master.
     """
     releasing.update_ansible_role_requirements_file(
-        filename=kwargs["file"], branchname=kwargs["os_branch"]
+        filename=kwargs["file"]
     )
 
 

--- a/osa_cli_releases/releasing.py
+++ b/osa_cli_releases/releasing.py
@@ -210,12 +210,12 @@ def get_sha_from_ref(repo_url, reference):
 def freeze_ansible_role_requirements_file(filename=""):
     """ Freezes a-r-r for master"""
     update_ansible_role_requirements_file(
-        filename, branchname="master", milestone_freeze=True
+        filename, milestone_freeze=True
     )
 
 
 def update_ansible_role_requirements_file(
-    filename="", branchname="", milestone_freeze=False
+    filename="", milestone_freeze=False
 ):
     """ Updates the SHA of each of the ansible roles based on branch given in argument
     Do not do anything on master except if milestone_freeze.
@@ -223,19 +223,6 @@ def update_ansible_role_requirements_file(
     Else, stable branches only get openstack roles bumped.
     Copies all the release notes of the roles at the same time.
     """
-    if branchname not in [
-        "master",
-        "stable/ocata",
-        "stable/pike",
-        "stable/queens",
-        "stable/rocky",
-        "stable/stein",
-        "stable/train",
-        "stable/ussuri",
-        "stable/victoria",
-        "stable/wallaby",
-    ]:
-        raise ValueError("Branch not recognized %s" % branchname)
 
     openstack_roles, external_roles, all_roles = sort_roles(filename)
 
@@ -266,7 +253,7 @@ def update_ansible_role_requirements_file(
                    role["src"], trackbranch, clone_root_path, depth="1"
                 )
                 # Unfreeze on master, not bump
-                if branchname == "master" and not milestone_freeze:
+                if trackbranch == "master" and not milestone_freeze:
                     print("Unfreeze master role")
                     role["version"] = trackbranch
                 # Freeze or Bump

--- a/osa_cli_releases/releasing.py
+++ b/osa_cli_releases/releasing.py
@@ -251,6 +251,8 @@ def update_ansible_role_requirements_file(
 
         copyreleasenotes = False
 
+        shallow_since = role.get("shallow_since")
+
         # We don't want to copy config_template renos even if it's an openstack
         # role, as it's not branched the same way.
         if role in openstack_roles and (not role["src"].endswith("config_template")):
@@ -259,24 +261,33 @@ def update_ansible_role_requirements_file(
         # Freeze sha by checking its trackbranch value
         # Do not freeze sha if trackbranch is None
         if trackbranch:
-            # Unfreeze on master, not bump
-            if branchname == "master" and not milestone_freeze:
-                print("Unfreeze master role")
-                role["version"] = trackbranch
-            # Freeze or Bump
-            else:
-                role["version"] = get_sha_from_ref(role["src"], trackbranch)
-                print("Bumped role %s to sha %s" % (role["name"], role["version"]))
+            try:
+                role_repo = clone_role(
+                   role["src"], trackbranch, clone_root_path, depth="1"
+                )
+                # Unfreeze on master, not bump
+                if branchname == "master" and not milestone_freeze:
+                    print("Unfreeze master role")
+                    role["version"] = trackbranch
+                # Freeze or Bump
+                else:
+                    role_head = role_repo.head()
+                    role["version"] = role_head.decode()
+                    print("Bumped role %s to sha %s" % (role["name"], role["version"]))
 
-        # Copy the release notes `Also handle the release notes
-        # If frozen, no need to copy release notes.
-        if copyreleasenotes and trackbranch:
-            print("Cloning and copying %s's release notes" % role["name"])
-            _, role_path = clone_role(
-                role["src"], branchname, clone_root_path, depth="1"
-            )
-            copy_role_releasenotes(role_path, "./")
-            shutil.rmtree(role_path)
+                    if shallow_since:
+                        head_timestamp = role_repo[role_head].commit_time
+                        head_datetime = datetime.fromtimestamp(head_timestamp)
+                        role["shallow_since"] = head_datetime.strftime('%Y-%m-%d')
+
+                # Copy the release notes `Also handle the release notes
+                # If frozen, no need to copy release notes.
+                if copyreleasenotes:
+                    print("Copying %s's release notes" % role["name"])
+                    copy_role_releasenotes(role_repo.path, "./")
+            finally:
+                shutil.rmtree(role_repo.path)
+
     shutil.rmtree(clone_root_path)
     print("Overwriting ansible-role-requirements")
     with open(filename, "w") as arryml:
@@ -310,7 +321,7 @@ def clone_role(url, branch, clone_root_path, clone_folder=None, depth=None):
     :param clone_root_path: The main folder in which the repo will be cloned.
     :param clone_folder: The relative folder name of the git clone to the clone_root_path
     :param depth(str): The git shallow clone depth
-    :returns: latest sha of the clone and its location
+    :returns: dulwich repository object
     """
     gitcall = ["git", "clone"]
 
@@ -328,7 +339,7 @@ def clone_role(url, branch, clone_root_path, clone_folder=None, depth=None):
 
     subprocess.check_call(gitcall)
     repo = Repo(dirpath)
-    return repo.head(), dirpath
+    return repo
 
 
 def copy_role_releasenotes(src_path, dest_path):


### PR DESCRIPTION
Branchname feels a bit redundant and unnecessary right now
since we were tacking head of trackbranch anyway.
The only reason to keep branchname was verification that branch exists
before running script, but I'd rather put trust in a-r-r maintainer
that non-existing branches won't be added there.
    
Also with dropping branchname we reduce work and stop maintaining list
of openstack branches.